### PR TITLE
Allows developers to create an importable jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,7 @@ development see the app [README.md](./src/main/app/README.md)
 
 ## Importing
 
-Baleen 3 is not available on maven central. If you would like to extend the capabilities of Baleen you need to create a standard, importable, jar instead of the executable jar that is created by default.
-To do this run:
-
-```shell
-mvn clean install -P importable
-```
-
-Then an importable jar will be installed in the local maven repository and can be added to your pom dependencies as:
+If you would like to extend the capabilities of Baleen you can add the dependency to your pom:
 
 ```xml
   <dependency>
@@ -80,18 +73,17 @@ Then an importable jar will be installed in the local maven repository and can b
   </dependency>
 ```
 
-and then add the `Baleen.class` to the Spring Boot Application, for example:
+and then add the `Baleen.class` to the your Spring Boot Application, for example:
 
 ```java
 package org.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 import uk.gov.dstl.baleen.Baleen;
 
-@EnableScheduling
+// Add other classes as required
 @SpringBootApplication(scanBasePackageClasses = { Baleen.class })
 public class BaleenExtended {
 
@@ -100,6 +92,15 @@ public class BaleenExtended {
   }
 }
 ```
+
+This uses an importable jar instead of the executable jar that is built by default. This is available on maven central. 
+To build this dependency manually run with the `importable` profile:
+
+```shell
+mvn clean install -P importable
+```
+
+Then an importable jar will be installed in the local maven repository and can be added to your pom dependencies as above.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,46 @@ The `./baleen-dev.sh` script can be used to run the jar straight from the target
 The app has all the usual typescript development support scripts within the app folder. For more information on the UI 
 development see the app [README.md](./src/main/app/README.md)
 
+## Importing
+
+Baleen 3 is not available on maven central. If you would like to extend the capabilities of Baleen you need to create a standard, importable, jar instead of the executable jar that is created by default.
+To do this run:
+
+```shell
+mvn clean install -P importable
+```
+
+Then an importable jar will be installed in the local maven repository and can be added to your pom dependencies as:
+
+```xml
+  <dependency>
+    <groupId>uk.gov.dstl</groupId>
+    <artifactId>baleen</artifactId>
+    <version>${baleen.version}</version>
+  </dependency>
+```
+
+and then add the `Baleen.class` to the Spring Boot Application, for example:
+
+```java
+package org.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import uk.gov.dstl.baleen.Baleen;
+
+@EnableScheduling
+@SpringBootApplication(scanBasePackageClasses = { Baleen.class })
+public class BaleenExtended {
+
+  public static void main(String[] args) {
+    SpringApplication.run(BaleenExtended.class, args);
+  }
+}
+```
+
 ## Licence
 
 Dstl (c) Crown Copyright 2020

--- a/pom.xml
+++ b/pom.xml
@@ -177,14 +177,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <layout>ZIP</layout>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
@@ -372,4 +364,29 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>executable</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-maven-plugin</artifactId>
+              <configuration>
+                <layout>ZIP</layout>
+              </configuration>
+            </plugin>
+          </plugins> 
+      </build>
+    </profile>
+    <profile>
+      <id>importable</id>
+      <build>
+      <!-- default to standard build -->
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Sets up 2 profiles

 - __executable__ (default) replicates the current ZIP style spring boot executable.
 - __importable__ produces a standard jar that can be imported into other projects.

See changes to README for motivation.